### PR TITLE
Fixed bug with protraction()

### DIFF
--- a/R/BiomechanicsFunctions.R
+++ b/R/BiomechanicsFunctions.R
@@ -667,7 +667,7 @@ protraction <- function(P1,P2,P3, Yaw, ...) {
     MagTVNorm <- vlength(TVNorm)
     MagFemurVectorTVNorm <- MagFemurVectorTV*MagTVNorm
     CosdotFemurVectorTV <- dotFemurVectorTV/MagFemurVectorTVNorm
-    FemTVAngA <- (acos(CosdotFemurVectorTV))*RAD2DEG
+    FemTVAngA <- (acos(CosdotFemurVectorTV))*(180/pi) #converting radians to degree
     # %makes a one column matrix of angles of the protraction/retraction angle
     FemTVAngInit[i] <- FemTVAngA
   }


### PR DESCRIPTION
Replaced a call to a MATLAB function (RAD2DEG) with a math expression. protraction() should run properly now